### PR TITLE
Fix composer require reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ to your `composer.json` file:
 ```json
 {
     "require": {
-        "beganovich/omnipay-checkoutcom": "~3.0"
+        "beganovich/omnipay-checkout": "~3.0"
     }
 }
 ```


### PR DESCRIPTION
The current reference doesn't exist, so you get the following error when trying to run it:

```sh
[InvalidArgumentException]
Could not find a matching version of package beganovich/omnipay-checkoutcom.
```